### PR TITLE
Use the `Makefile` so version info is set

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -21,14 +21,11 @@ parts:
     build-packages:
       - libsystemd-dev
     override-build: |
-      go build ./cmd/loki
-      go build ./cmd/logcli
-      go build ./cmd/loki-canary
-      go build --tags=promtail_journal_enabled ./clients/cmd/promtail
-      install -D -m755 ./loki ${CRAFT_PART_INSTALL}/usr/bin/loki
-      install -D -m755 ./loki-canary ${CRAFT_PART_INSTALL}/usr/bin/loki-canary
-      install -D -m755 ./logcli ${CRAFT_PART_INSTALL}/usr/bin/logcli
-      install -D -m755 ./promtail ${CRAFT_PART_INSTALL}/usr/bin/promtail
+      PROMTAIL_JOURNAL_ENABLED=1 make -j$(grep -c ^processor /proc/cpuinfo) all
+      install -D -m755 ./cmd/loki/loki ${CRAFT_PART_INSTALL}/usr/bin/loki
+      install -D -m755 ./cmd/loki-canary/loki-canary ${CRAFT_PART_INSTALL}/usr/bin/loki-canary
+      install -D -m755 ./cmd/logcli/logcli ${CRAFT_PART_INSTALL}/usr/bin/logcli
+      install -D -m755 ./clients/cmd/promtail/promtail ${CRAFT_PART_INSTALL}/usr/bin/promtail
     stage:
       - usr/bin/loki
       - usr/bin/loki-canary


### PR DESCRIPTION
All of the info from `loki -version` is set by ldflags as part of the go build.

We could set these ourselves, but the `Makefile` already has all the logic to pull it out from git, and then we won't diverge.

Use the Makefile var to enable journald for promtail so it stays the same.