### PR TITLE
add new versions and fix certificates

### DIFF
--- a/2.9.2/rockcraft.yaml
+++ b/2.9.2/rockcraft.yaml
@@ -41,10 +41,14 @@ parts:
       loki-local-config.yaml: etc/loki/loki-local-config.yaml
     stage:
       - etc/loki/loki-local-config.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:
       - loki
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/2.9.3/rockcraft.yaml
+++ b/2.9.3/rockcraft.yaml
@@ -41,10 +41,14 @@ parts:
       loki-local-config.yaml: etc/loki/loki-local-config.yaml
     stage:
       - etc/loki/loki-local-config.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:
       - loki
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/2.9.4/rockcraft.yaml
+++ b/2.9.4/rockcraft.yaml
@@ -41,10 +41,14 @@ parts:
       loki-local-config.yaml: etc/loki/loki-local-config.yaml
     stage:
       - etc/loki/loki-local-config.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:
       - loki
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/2.9.5/loki-local-config.yaml
+++ b/2.9.5/loki-local-config.yaml
@@ -1,0 +1,50 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false

--- a/2.9.5/rockcraft.yaml
+++ b/2.9.5/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: loki
 summary: Loki in a ROCK.
 description: "Loki is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus."
-version: "2.8.4"
+version: "2.9.5"
 base: ubuntu:22.04
 license: AGPL-3.0
 services:
@@ -16,7 +16,7 @@ parts:
     plugin: go
     source: https://github.com/grafana/loki
     source-type: git
-    source-tag: "v2.8.4"
+    source-tag: "v2.9.5"
     build-snaps:
       - go/1.20/stable
     build-environment:


### PR DESCRIPTION
## Issue

Closes #26 and makes sure sure the default certificates are not missing from `/etc/ssl/certs`.

Besides that, this PR also adds new versions that had pending PRs, and renames the build part for consistency with other rocks :)