### PR TITLE
feat: add lokitool to 3.5.1

### DIFF
--- a/3.5.1/rockcraft.yaml
+++ b/3.5.1/rockcraft.yaml
@@ -24,16 +24,18 @@ parts:
     build-packages:
       - libsystemd-dev
     override-build: |
-      PROMTAIL_JOURNAL_ENABLED=1 make -j$(grep -c ^processor /proc/cpuinfo) all
+      PROMTAIL_JOURNAL_ENABLED=1 make -j$(grep -c ^processor /proc/cpuinfo) all lokitool
       install -D -m755 ./cmd/loki/loki ${CRAFT_PART_INSTALL}/usr/bin/loki
       install -D -m755 ./cmd/loki-canary/loki-canary ${CRAFT_PART_INSTALL}/usr/bin/loki-canary
       install -D -m755 ./cmd/logcli/logcli ${CRAFT_PART_INSTALL}/usr/bin/logcli
       install -D -m755 ./clients/cmd/promtail/promtail ${CRAFT_PART_INSTALL}/usr/bin/promtail
+      install -D -m755 ./cmd/lokitool/lokitool ${CRAFT_PART_INSTALL}/usr/bin/lokitool
     stage:
       - usr/bin/loki
       - usr/bin/loki-canary
       - usr/bin/logcli
       - usr/bin/promtail
+      - usr/bin/lokitool
   default-config:
     plugin: dump
     source: .

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ push-to-registry version:
     "docker://localhost:32000/${rock_name}-dev:${version}"
 
 # Pack a rock of a specific version
-pack version:
+pack version=latest_version:
   cd "$version" && rockcraft pack
 
 # `rockcraft clean` for a specific version


### PR DESCRIPTION
## Issue
Closes #77 

## Solution
The [`all`](https://github.com/grafana/loki/blob/05fb19c530c15e8977d7469b065ae8a2718c5275/Makefile#L160) target for Loki builds `promtail logcli loki loki-canary`, so not `lokitool`.

This PR also adds [`lokitool`](https://github.com/grafana/loki/blob/05fb19c530c15e8977d7469b065ae8a2718c5275/Makefile#L250) from the same `Makefile`.