### PR TITLE
Update Go version from 1.24 to 1.25

### DIFF
--- a/3.6.5/rockcraft.yaml
+++ b/3.6.5/rockcraft.yaml
@@ -18,7 +18,7 @@ parts:
     source-type: git
     source-tag: "v3.6.5"
     build-snaps:
-      - go/1.24/stable
+      - go/1.25/candidate
     build-environment:
       - BUILD_IN_CONTAINER: "false"
     build-packages:


### PR DESCRIPTION
## Issue
Upstream now build loki with go 1.25.


## Solution
Bump build snap to 1.25.


## Context
Tangentially related to #118.